### PR TITLE
Patch User Service

### DIFF
--- a/backend/user-service/src/__tests__/unit/post-user.test.ts
+++ b/backend/user-service/src/__tests__/unit/post-user.test.ts
@@ -9,11 +9,15 @@ const dbMock = db;
 
 describe("POST /api/users", () => {
   describe("Given the request body payload is valid", () => {
-    it("should return 201 with a message of User Created", async () => {
+    it("should return 201 with a message of User Created and the registered userId", async () => {
       // Arrange
       const requestBody = testPayloads.getPostUserPayload();
       dbMock.user.findFirst = jest.fn().mockReturnValue(null);
-      dbMock.user.create = jest.fn().mockResolvedValue("userId123");
+      dbMock.user.create = jest
+        .fn()
+        .mockResolvedValue(
+          testPayloads.getUserPayload({ userId: "userId123" })
+        );
       dbMock.preferences.create = jest.fn().mockResolvedValue(null);
 
       // Act
@@ -26,6 +30,7 @@ describe("POST /api/users", () => {
         data: requestBody,
       });
       expect(statusCode).toBe(HttpStatusCode.CREATED);
+      expect(body.id).toBe("userId123");
       expect(body.message).toBe("User created.");
     });
   });

--- a/backend/user-service/src/controllers/handlers/post-handler.ts
+++ b/backend/user-service/src/controllers/handlers/post-handler.ts
@@ -47,6 +47,10 @@ export const postUser = async (request: Request, response: Response) => {
       data: createUserBody,
     });
 
+    if (!user) {
+      throw new Error("Failed to register user.");
+    }
+
     await db.preferences.create({
       data: {
         userId: user.id,
@@ -56,7 +60,9 @@ export const postUser = async (request: Request, response: Response) => {
       },
     });
 
-    response.status(HttpStatusCode.CREATED).json({ message: "User created." });
+    response
+      .status(HttpStatusCode.CREATED)
+      .json({ id: user.id, message: "User created." });
   } catch (error) {
     if (error instanceof ZodError) {
       response.status(HttpStatusCode.BAD_REQUEST).json({

--- a/backend/user-service/src/models/prisma/schema.prisma
+++ b/backend/user-service/src/models/prisma/schema.prisma
@@ -27,7 +27,7 @@ model User {
 
 model Preferences {
   userId String @unique
-  user   User   @relation(fields: [userId], references: [id])
+  user   User   @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   languages    String[]
   difficulties String[]


### PR DESCRIPTION
# Pull Request

## Description
<!-- [Provide a brief description of the changes introduced by this PR. Explain the problem it solves or the feature it adds.] -->
There is a bug in DELETE /users/:userId, as because the Preferences table has a foreign key referencing the User table. And their relation does not have a `onDelete: Cascade`. So when a user is deleted, the preferences will still be there. 

Furthermore, as the current response of POST /users is useless message, we decide to change it such that it will return the registered user id. 

## Related Issue(s)
<!-- [Link to any related issues or tasks, e.g., "Closes #123" or "Fixes #456."] -->

## Changes Made
<!-- [List the specific changes made in this PR, such as code modifications, new files, or updates to documentation.] -->
- update user-service db schema for preferences to add the onDelete cascade relation
- update POST /users response to return the user id created

## Screenshots (if applicable)
<!-- [Include screenshots or images to visually showcase the changes, if applicable.] -->

## Checklist
- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->

