### PR TITLE
Fix input validation error messages disappearing for name/password

### DIFF
--- a/frontend/src/components/login/Login.tsx
+++ b/frontend/src/components/login/Login.tsx
@@ -51,6 +51,8 @@ export function LoginComponent() {
     setIsCheckPasswordVisible(!isCheckPasswordVisible);
   const toggleSignUp = () => setIsSignUp(!isSignUp);
 
+  // Validation
+
   useEffect(() => {
     setArePasswordsEqual(
       !(password !== checkPassword && password !== "" && checkPassword !== "")
@@ -60,10 +62,13 @@ export function LoginComponent() {
       setErrorMsg("Password should contain 8 characters or more.");
     } else if (!arePasswordsEqual) {
       setErrorMsg("Passwords do not match. Please try again.");
+    } else if (name !== "" && name.length < 2) {
+      setErrorMsg("Name has to contain at least 2 characters");
     } else {
       setErrorMsg("");
     }
   }, [
+    name,
     password,
     checkPassword,
     setPassword,
@@ -71,19 +76,11 @@ export function LoginComponent() {
     arePasswordsEqual,
   ]);
 
-  useEffect(() => {
-    if (name !== "" && name.length < 2) {
-      setErrorMsg("Name has to contain at least 2 characters");
-    } else {
-      setErrorMsg("");
-    }
-  });
-
   async function submitNewUser(e: FormEvent<HTMLFormElement>) {
     e.preventDefault();
 
     if (errorMsg !== "") {
-      displayToast("Please fix the errors before submitting.", ToastType.ERROR);
+      displayToast("Sign up failed. Please address the errors before submitting.", ToastType.ERROR);
       return;
     }
 
@@ -113,7 +110,6 @@ export function LoginComponent() {
           ToastType.ERROR
         );
       } else {
-        console.log(error);
         displayToast(
           "Something went wrong. Please refresh and try again.",
           ToastType.ERROR


### PR DESCRIPTION
# Pull Request

(Minor fix)
Previously, the passwords and name used the same error message but were in different useEffects(). Hence they were erasing each other's error messages when updated.

## Description

Moved the name validation into the if-else statement that validate the passwords as well, such that they do not conflict.

## Related Issue(s)

-

## Changes Made


## Screenshots (if applicable)


## Checklist
- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->

