### PR TITLE
Ensure Collaboration Workspace is able to render when matching redirects

### DIFF
--- a/backend/matching-service/src/controllers/handlers/socket-handler.ts
+++ b/backend/matching-service/src/controllers/handlers/socket-handler.ts
@@ -1,161 +1,178 @@
-import { Socket } from 'socket.io';
-import { io } from '../../app';
-import RoomManager from '../../lib/utils/roomManager';
-import Preferences from '../../models/types/preferences';
-import Partner from '../../models/types/partner';
-import Room from '../../models/types/room';
-import Logger from '../../lib/utils/logger'
-import { generateRoomId } from '../../lib/utils/encoder';
+import { Socket } from "socket.io";
+import { io } from "../../app";
+import RoomManager from "../../lib/utils/roomManager";
+import Preferences from "../../models/types/preferences";
+import Partner from "../../models/types/partner";
+import Room from "../../models/types/room";
+import Logger from "../../lib/utils/logger";
+import { generateRoomId } from "../../lib/utils/encoder";
 
 const timeout = Number(process.env.MATCHING_TIMEOUT) || 60000;
 const rm: RoomManager = RoomManager.getInstance();
 const activeSockets = new Set();
 
-const handleMatching = (socket: Socket, request: {
-    user: Partner,
-    preferences: Preferences,
-}) => {
-    try {
-        if (!activeSockets.has(socket.id)) {
-            Logger.debug(`[${socket.id}][handleMatching] Matching request received.`);
-            setTimeout(() => {
-                request.user.socketId = socket.id;
-                rm.findMatchElseCreateRoom(
-                    request.user,
-                    request.preferences,
-                    room => handleMatched(socket, room, request.user),
-                    room => handleCreateRoom(socket, room),
-                )
-            }, 2000);
-            activeSockets.add(socket.id);
-        }
-    } catch (error) {
-        notifyError(socket, error);
+const handleMatching = (
+  socket: Socket,
+  request: {
+    user: Partner;
+    preferences: Preferences;
+  }
+) => {
+  try {
+    if (!activeSockets.has(socket.id)) {
+      Logger.debug(`[${socket.id}][handleMatching] Matching request received.`);
+      setTimeout(() => {
+        request.user.socketId = socket.id;
+        rm.findMatchElseCreateRoom(
+          request.user,
+          request.preferences,
+          (room) => handleMatched(socket, room, request.user),
+          (room) => handleCreateRoom(socket, room)
+        );
+      }, 2000);
+      activeSockets.add(socket.id);
     }
-}
+  } catch (error) {
+    notifyError(socket, error);
+  }
+};
 
 const handleMatched = (socket: Socket, room: Room, requester: Partner) => {
-    // ensure owner does not join the room twice
-    if (room.owner.id === requester.id) {
-        return;
-    }
+  // ensure owner does not join the room twice
+  if (room.owner.id === requester.id) {
+    return;
+  }
 
-    Logger.debug(`[${socket.id}][handleMatched] Matched with room_${room.id}, ${socket.id} to join`);
-    socket.join(room.id)
+  Logger.debug(
+    `[${socket.id}][handleMatched] Matched with room_${room.id}, ${socket.id} to join`
+  );
+  socket.join(room.id);
 
-    // inform owner 
-    socket.to(room.id).emit("matched", {
-        room: room.id,
-        partner: requester,
-        owner: room.owner.id,
-        preferences: room.preference
-    })
+  // inform owner
+  socket.to(room.id).emit("matched", {
+    room: room.id,
+    partner: requester,
+    owner: room.owner.id,
+    preferences: room.preference,
+  });
 
-    // inform self
-    socket.emit("matched", {
-        room: room.id,
-        partner: room.owner,
-        owner: room.owner.id
-    })
-}
+  // inform self
+  socket.emit("matched", {
+    room: room.id,
+    partner: room.owner,
+    owner: room.owner.id,
+  });
+};
 
 const handleCreateRoom = (socket: Socket, room: Room) => {
-    Logger.debug(`[${socket.id}][handleCreateRoom] Created room_${room.id}, ${socket.id} to join`);
-    socket.join(room.id);
+  Logger.debug(
+    `[${socket.id}][handleCreateRoom] Created room_${room.id}, ${socket.id} to join`
+  );
+  socket.join(room.id);
 
-    // Register timeout handler
-    setTimeout(() => {
-        if (!room.matched) {
-            Logger.debug(`[${socket.id}][handleCreateRoom.callback] Timeout`);
+  // Register timeout handler
+  setTimeout(() => {
+    if (!room.matched) {
+      Logger.debug(`[${socket.id}][handleCreateRoom.callback] Timeout`);
 
-            socket.emit("no_match");
-            rm.closeRoom(room.id);
-        }
-    }, timeout)
-}
+      socket.emit("no_match");
+      rm.closeRoom(room.id);
+    }
+  }, timeout);
+};
 
 const handleReady = (socket: Socket, ready: boolean) => {
-    Logger.debug(`[${socket.id}][handleReady]: notify ready state change`);
+  Logger.debug(`[${socket.id}][handleReady]: notify ready state change`);
 
-    try {
-        socket.rooms.forEach(r => {
-            if (r !== socket.id) {
-                socket.to(r).emit("partner_ready_change", ready);
-            }
-        })
-    } catch (error) {
-        notifyError(socket, error);
-    }
-}
+  try {
+    socket.rooms.forEach((r) => {
+      if (r !== socket.id) {
+        socket.to(r).emit("partner_ready_change", ready);
+      }
+    });
+  } catch (error) {
+    notifyError(socket, error);
+  }
+};
 
 const handleStart = (socket: Socket, problemId: string) => {
-    Logger.debug(`[${socket.id}][notifyStart]: Generating room id for collab session`);
+  Logger.debug(
+    `[${socket.id}][notifyStart]: Generating room id for collab session`
+  );
 
-    socket.rooms.forEach(r => {
-        if (r !== socket.id) {
-            const room = rm.getRoomById(r);
-            if (room) {
-                const lang = rm.chooseRandomItem(room.preference.languages) as string;
-                const roomId = generateRoomId(
-                        room.owner.id,
-                        room.partner.id,
-                        problemId,
-                        lang.toLowerCase()
-                    );
+  socket.rooms.forEach((r) => {
+    if (r !== socket.id) {
+      const room = rm.getRoomById(r);
+      if (room) {
+        const lang = rm.chooseRandomItem(room.preference.languages) as string;
+        const roomId = generateRoomId(
+          room.owner.id,
+          room.partner.id,
+          problemId,
+          lang
+        );
 
-                const roomConfig = {
-                    id: roomId,
-                    owner: room.owner.id,
-                    partner: room.partner.id,
-                    questionId: problemId,
-                    language: lang
-                }
+        const roomConfig = {
+          id: roomId,
+          owner: room.owner.id,
+          partner: room.partner.id,
+          questionId: problemId,
+          language: lang,
+        };
 
-                io.sockets.in(r).emit("redirect_collaboration", roomConfig);
-            }
-        }
-    })
-}
+        io.sockets.in(r).emit("redirect_collaboration", roomConfig);
+      }
+    }
+  });
+};
 
 const handleCancel = (socket: Socket) => {
-    Logger.debug(`[${socket.id}][handleCancel]: Close room and inform partner`);
-    console.log(socket.rooms);
-    
-    socket.rooms.forEach(r => {
-        if (r !== socket.id) {
-            Logger.debug(`[NotifyClosed]: room ${r}`);
+  Logger.debug(`[${socket.id}][handleCancel]: Close room and inform partner`);
+  console.log(socket.rooms);
 
-            const room = rm.getRoomById(r);
-            if (room) {
-                room.owner ? activeSockets.delete((room.owner as Partner).socketId): {} ;
-                room.partner ? activeSockets.delete((room.partner as Partner).socketId): {};
-            }
+  socket.rooms.forEach((r) => {
+    if (r !== socket.id) {
+      Logger.debug(`[NotifyClosed]: room ${r}`);
 
-            io.to(r).emit("room_closed");
-            rm.closeRoom(r);
-        }
-    })
-}
+      const room = rm.getRoomById(r);
+      if (room) {
+        room.owner
+          ? activeSockets.delete((room.owner as Partner).socketId)
+          : {};
+        room.partner
+          ? activeSockets.delete((room.partner as Partner).socketId)
+          : {};
+      }
+
+      io.to(r).emit("room_closed");
+      rm.closeRoom(r);
+    }
+  });
+};
 
 const notifyError = (socket: Socket, error: any) => {
-    Logger.debug(`[${socket.id}][notifyError]: `, error);
-    socket.disconnect();
-}
+  Logger.debug(`[${socket.id}][notifyError]: `, error);
+  socket.disconnect();
+};
 
 export const SocketHandler = (socket: Socket) => {
-    Logger.debug("Socket connected: " + socket.id);
+  Logger.debug("Socket connected: " + socket.id);
 
-    // Handles matching request, tries to find a room first before creating one
-    socket.on("request_match", (request: any) => handleMatching(socket, request));
+  // Handles matching request, tries to find a room first before creating one
+  socket.on("request_match", (request: any) => handleMatching(socket, request));
 
-    // Notifies partner of users ready status
-    socket.on("user_update_ready", (ready: boolean) => handleReady(socket, ready));
+  // Notifies partner of users ready status
+  socket.on("user_update_ready", (ready: boolean) =>
+    handleReady(socket, ready)
+  );
 
-    // Notify matching server that clients should already start collab
-    socket.on("start_collaboration", (problemId: string) => handleStart(socket, problemId));
+  // Notify matching server that clients should already start collab
+  socket.on("start_collaboration", (problemId: string) =>
+    handleStart(socket, problemId)
+  );
 
-    socket.on("disconnecting", (data: any) => handleCancel(socket));
-    socket.on('disconnect', () => {
-        activeSockets.delete(socket.id);
-    });
-}
+  socket.on("disconnecting", (data: any) => handleCancel(socket));
+  socket.on("disconnect", () => {
+    activeSockets.delete(socket.id);
+  });
+};

--- a/backend/matching-service/src/lib/utils/encoder.ts
+++ b/backend/matching-service/src/lib/utils/encoder.ts
@@ -1,45 +1,54 @@
-import crypto from 'crypto';
-import Preferences from '../../models/types/preferences';
-import Complexity from '../enums/Complexity';
-import Language from '../enums/Language';
-import Topic from '../enums/Topic';
+import crypto from "crypto";
+import Preferences from "../../models/types/preferences";
+import Complexity from "../enums/Complexity";
+import Language from "../enums/Language";
+import Topic from "../enums/Topic";
 
 function enumValues<T>(e: any): T[] {
-    return Object.keys(e).map((key) => e[key]);
+  return Object.keys(e).map((key) => e[key]);
 }
 
 export function encodeEnum<E extends object>(enumObj: E, values: E[]): string {
-    if (values.length === 0) {
-        return '0'.repeat(Object.keys(enumObj).length / 2);
-    }
+  if (values.length === 0) {
+    return "0".repeat(Object.keys(enumObj).length / 2);
+  }
 
-    let stringValues = values.map(x => (x as String).toUpperCase())
+  let stringValues = values.map((x) => (x as String).toUpperCase());
 
-    const binaryCode = enumValues(enumObj)
-        .map((enumValue) => (stringValues.includes(enumValue as string) ? '1' : '0'))
-        .join('');
+  const binaryCode = enumValues(enumObj)
+    .map((enumValue) =>
+      stringValues.includes(enumValue as string) ? "1" : "0"
+    )
+    .join("");
 
-    return binaryCode;
+  return binaryCode;
 }
 
 export function binaryToHex(...input: string[]): string {
-    var binaryString = input.join("");
-    const decimalValue = parseInt(binaryString, 2); 
-    const hexString = decimalValue.toString(16); // Convert decimal to hexadecimal
-    return hexString;
+  var binaryString = input.join("");
+  const decimalValue = parseInt(binaryString, 2);
+  const hexString = decimalValue.toString(16); // Convert decimal to hexadecimal
+  return hexString;
 }
-
 
 export function encodePreferences(preference: Preferences): string {
-    return binaryToHex(
-        encodeEnum(Language, preference.languages),
-        encodeEnum(Complexity, preference.difficulties),
-        encodeEnum(Topic, preference.topics));
+  return binaryToHex(
+    encodeEnum(Language, preference.languages),
+    encodeEnum(Complexity, preference.difficulties),
+    encodeEnum(Topic, preference.topics)
+  );
 }
 
-export function generateRoomId(ownerId: string, partnerId: string, questionId: string, language: string): string {
-  const inputString = ownerId + partnerId + questionId + language;
-  const hash = crypto.createHash('sha256');
+export function generateRoomId(
+  ownerId: string,
+  partnerId: string,
+  questionId: string,
+  language: string
+): string {
+  const inputString = ownerId + partnerId + questionId + language.toLowerCase();
+
+  const hash = crypto.createHash("sha256");
   hash.update(inputString);
-  return hash.digest('hex').slice(0, 20);
+
+  return hash.digest("hex").slice(0, 20);
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@monaco-editor/react": "^4.5.2",
         "@nextui-org/react": "^2.1.10",
+        "@tanstack/react-query": "^4.35.7",
         "@types/bcrypt": "^5.0.0",
         "@types/node": "20.5.7",
         "@types/react": "18.2.21",
@@ -2316,6 +2317,41 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "4.35.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.7.tgz",
+      "integrity": "sha512-PgDJtX75ubFS0WCYFM7DqEoJ4QbxU3S5OH3gJSI40xr7UVVax3/J4CM3XUMOTs+EOT5YGEfssi3tfRVGte4DEw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "4.35.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.7.tgz",
+      "integrity": "sha512-0MankquP/6EOM2ATfEov6ViiKemey5uTbjGlFMX1xGotwNaqC76YKDMJdHumZupPbZcZPWAeoPGEHQmVKIKoOQ==",
+      "dependencies": {
+        "@tanstack/query-core": "4.35.7",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-native": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/@types/bcrypt": {
@@ -8405,12 +8441,10 @@
       }
     },
     "@nextui-org/shared-icons": {
-      "version": "2.0.3",
-      "requires": {}
+      "version": "2.0.3"
     },
     "@nextui-org/shared-utils": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/skeleton": {
       "version": "2.0.16",
@@ -8641,12 +8675,10 @@
       }
     },
     "@nextui-org/use-clipboard": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/use-data-scroll-overflow": {
-      "version": "2.1.0",
-      "requires": {}
+      "version": "2.1.0"
     },
     "@nextui-org/use-disclosure": {
       "version": "2.0.3",
@@ -8669,8 +8701,7 @@
       }
     },
     "@nextui-org/use-is-mounted": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/use-pagination": {
       "version": "2.0.2",
@@ -8679,16 +8710,13 @@
       }
     },
     "@nextui-org/use-safe-layout-effect": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/use-scroll-position": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/use-update-effect": {
-      "version": "2.0.2",
-      "requires": {}
+      "version": "2.0.2"
     },
     "@nextui-org/user": {
       "version": "2.0.19",
@@ -9278,8 +9306,7 @@
       }
     },
     "@react-types/shared": {
-      "version": "3.19.0",
-      "requires": {}
+      "version": "3.19.0"
     },
     "@react-types/switch": {
       "version": "3.4.0",
@@ -9324,6 +9351,20 @@
       "version": "0.5.2",
       "requires": {
         "tslib": "^2.4.0"
+      }
+    },
+    "@tanstack/query-core": {
+      "version": "4.35.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-4.35.7.tgz",
+      "integrity": "sha512-PgDJtX75ubFS0WCYFM7DqEoJ4QbxU3S5OH3gJSI40xr7UVVax3/J4CM3XUMOTs+EOT5YGEfssi3tfRVGte4DEw=="
+    },
+    "@tanstack/react-query": {
+      "version": "4.35.7",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-4.35.7.tgz",
+      "integrity": "sha512-0MankquP/6EOM2ATfEov6ViiKemey5uTbjGlFMX1xGotwNaqC76YKDMJdHumZupPbZcZPWAeoPGEHQmVKIKoOQ==",
+      "requires": {
+        "@tanstack/query-core": "4.35.7",
+        "use-sync-external-store": "^1.2.0"
       }
     },
     "@types/bcrypt": {
@@ -9666,8 +9707,7 @@
       "version": "8.10.0"
     },
     "acorn-jsx": {
-      "version": "5.3.2",
-      "requires": {}
+      "version": "5.3.2"
     },
     "ajv": {
       "version": "6.12.6",
@@ -10546,8 +10586,7 @@
     },
     "eslint-config-prettier": {
       "version": "9.0.0",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-import-resolver-node": {
       "version": "0.3.9",
@@ -10697,8 +10736,7 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "4.6.0",
-      "requires": {}
+      "version": "4.6.0"
     },
     "eslint-scope": {
       "version": "7.2.2",
@@ -11786,8 +11824,7 @@
       }
     },
     "react-icons": {
-      "version": "4.11.0",
-      "requires": {}
+      "version": "4.11.0"
     },
     "react-is": {
       "version": "16.13.1"
@@ -12280,8 +12317,7 @@
       "dev": true
     },
     "ts-api-utils": {
-      "version": "1.0.2",
-      "requires": {}
+      "version": "1.0.2"
     },
     "ts-interface-checker": {
       "version": "0.1.13"
@@ -12390,12 +12426,10 @@
       }
     },
     "use-composed-ref": {
-      "version": "1.3.0",
-      "requires": {}
+      "version": "1.3.0"
     },
     "use-isomorphic-layout-effect": {
-      "version": "1.1.2",
-      "requires": {}
+      "version": "1.1.2"
     },
     "use-latest": {
       "version": "1.2.1",
@@ -12411,8 +12445,7 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.0",
-      "requires": {}
+      "version": "1.2.0"
     },
     "util": {
       "version": "0.12.5",
@@ -12508,8 +12541,7 @@
       "version": "1.0.2"
     },
     "ws": {
-      "version": "8.11.0",
-      "requires": {}
+      "version": "8.11.0"
     },
     "xml2js": {
       "version": "0.5.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -44,11 +44,9 @@
     "socket.io-client": "^4.7.2",
     "react-split": "^2.0.14",
     "react-toastify": "^9.1.3",
-    "socket.io-client": "^4.7.2",
     "swr": "^2.2.2",
     "tailwindcss": "3.3.3",
-    "typescript": "5.2.2",
-    "uuid": "^9.0.1"
+    "typescript": "5.2.2"
   },
   "devDependencies": {
     "@types/bcrypt": "^5.0.0",

--- a/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
+++ b/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
@@ -29,15 +29,15 @@ const page: FC<pageProps> = ({ params: { roomId } }) => {
   useEffect(() => {
     handleConnectToRoom(roomId, questionId, partnerId, language);
 
+    if (isNotFoundError) {
+      return notFound();
+    }
+
     return () => {
       console.log("disconnecting from room");
       handleDisconnectFromRoom();
     };
   }, []);
-
-  if (isNotFoundError) {
-    return notFound();
-  }
 
   return (
     <div>

--- a/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
+++ b/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Workspace from "@/components/collab/Workspace";
-import { FC, useEffect } from "react";
+import { FC, useEffect, useState } from "react";
 import { useCollabContext } from "@/contexts/collab";
 import LogoLoadingComponent from "@/components/common/LogoLoadingComponent";
 import ChatSpaceToggle from "@/components/collab/chat/ChatSpaceToggle";
+import { useSearchParams } from "next/navigation";
 
 interface pageProps {
   params: {
@@ -13,19 +14,22 @@ interface pageProps {
 }
 
 const page: FC<pageProps> = ({ params: { roomId } }) => {
+  const searchParams = useSearchParams();
+  const partnerId = searchParams.get("partnerId")!;
+  const questionId = searchParams.get("questionId")!;
+  const language = searchParams.get("language")!;
+
   const { handleConnectToRoom, handleDisconnectFromRoom, isLoading } =
     useCollabContext();
 
   useEffect(() => {
-    handleConnectToRoom(roomId);
+    handleConnectToRoom(roomId, questionId, partnerId, language);
+
     return () => {
       console.log("disconnecting from room");
       handleDisconnectFromRoom();
     };
   }, []);
-
-  // FE requirements:
-  // TODO: create a chat button that will open the chat panel when clicked
 
   return (
     <div>

--- a/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
+++ b/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
@@ -5,7 +5,7 @@ import { FC, useEffect, useState } from "react";
 import { useCollabContext } from "@/contexts/collab";
 import LogoLoadingComponent from "@/components/common/LogoLoadingComponent";
 import ChatSpaceToggle from "@/components/collab/chat/ChatSpaceToggle";
-import { useSearchParams } from "next/navigation";
+import { notFound, useSearchParams } from "next/navigation";
 
 interface pageProps {
   params: {
@@ -19,8 +19,12 @@ const page: FC<pageProps> = ({ params: { roomId } }) => {
   const questionId = searchParams.get("questionId")!;
   const language = searchParams.get("language")!;
 
-  const { handleConnectToRoom, handleDisconnectFromRoom, isLoading } =
-    useCollabContext();
+  const {
+    handleConnectToRoom,
+    handleDisconnectFromRoom,
+    isLoading,
+    isNotFoundError,
+  } = useCollabContext();
 
   useEffect(() => {
     handleConnectToRoom(roomId, questionId, partnerId, language);
@@ -30,6 +34,10 @@ const page: FC<pageProps> = ({ params: { roomId } }) => {
       handleDisconnectFromRoom();
     };
   }, []);
+
+  if (isNotFoundError) {
+    return notFound();
+  }
 
   return (
     <div>

--- a/frontend/src/app/(pages)/questions/[id]/page.tsx
+++ b/frontend/src/app/(pages)/questions/[id]/page.tsx
@@ -3,7 +3,7 @@ import Question from "@/types/question";
 import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import parse from "html-react-parser";
-import ProblemDescription from "@/components/collab/ProblemDescription";
+import ProblemDescription from "@/components/common/ProblemDescription";
 import LogoLoadingComponent from "@/components/common/LogoLoadingComponent";
 
 async function getQuestion(id: string) {

--- a/frontend/src/app/api/profile/upload/image/route.ts
+++ b/frontend/src/app/api/profile/upload/image/route.ts
@@ -28,7 +28,7 @@ export async function POST(request: NextRequest) {
       file.type,
       fileBuffer
     );
-    console.log(imageUrl);
+
     return NextResponse.json({ imageUrl }, { status: HttpStatusCode.OK });
   } catch (error: any) {
     console.log(error);

--- a/frontend/src/components/collab/CodeEditor.tsx
+++ b/frontend/src/components/collab/CodeEditor.tsx
@@ -1,6 +1,6 @@
 import { useCollabContext } from "@/contexts/collab";
 import { Editor } from "@monaco-editor/react";
-import { FC, RefObject, useEffect, useState } from "react";
+import { FC } from "react";
 
 interface CodeEditorProps {
   currentCode: string;

--- a/frontend/src/components/collab/CodeEditorNavbar.tsx
+++ b/frontend/src/components/collab/CodeEditorNavbar.tsx
@@ -16,8 +16,7 @@ interface CodeEditorNavbarProps {
 const CodeEditorNavbar: FC<CodeEditorNavbarProps> = ({
   handleResetToDefaultCode,
 }) => {
-  const { partner, matchedLanguage, roomId, socketService, isSocketConnected } =
-    useCollabContext();
+  const { partner, matchedLanguage, isSocketConnected } = useCollabContext();
   const language = matchedLanguage || "";
   const [isFullScreen, setIsFullScreen] = useState<boolean>(false);
   const [isReady, setIsReady] = useState<boolean>(false);
@@ -58,7 +57,6 @@ const CodeEditorNavbar: FC<CodeEditorNavbarProps> = ({
 
   return (
     <div className="flex items-center justify-between h-11 w-full">
-      {/* Show the coding language matched */}
       <div className="flex items-center m-2">
         <div className="text-lg">
           <Icons.BsFileEarmarkCode />
@@ -148,7 +146,7 @@ const CodeEditorNavbar: FC<CodeEditorNavbarProps> = ({
               End Session
             </Button>
           </CodeEditorNavBarTooltip>
-          <EndSessionModal roomId={roomId} onClose={onClose} isOpen={isOpen} />
+          <EndSessionModal onClose={onClose} isOpen={isOpen} />
         </div>
       </div>
     </div>

--- a/frontend/src/components/collab/EndSessionModal.tsx
+++ b/frontend/src/components/collab/EndSessionModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { CLIENT_ROUTES } from "@/common/constants";
+import { useCollabContext } from "@/contexts/collab";
 import {
   Button,
   Divider,
@@ -13,22 +14,25 @@ import {
 import { useRouter } from "next/navigation";
 
 interface EndSessionModalProps {
-  roomId: string;
   isOpen: boolean;
   onClose: () => void;
 }
 
 export default function EndSessionModal({
-  roomId,
   isOpen,
   onClose,
 }: EndSessionModalProps) {
   const router = useRouter();
 
+  const { handleDisconnectFromRoom } = useCollabContext();
+
   const handleTerminateSession = () => {
     // assume we can exit the room by calling an endpoint provided in either collab or matching
-    console.log(`Quit room ${roomId}`);
+    console.log("disconnecting from room");
+    handleDisconnectFromRoom();
+
     onClose();
+
     router.push(CLIENT_ROUTES.HOME);
   };
 

--- a/frontend/src/components/collab/ProblemPanel.tsx
+++ b/frontend/src/components/collab/ProblemPanel.tsx
@@ -1,9 +1,14 @@
-import ProblemDescription from "./ProblemDescription";
+import { useCollabContext } from "@/contexts/collab";
+import ProblemDescription from "../common/ProblemDescription";
 
 const ProblemPanel = () => {
+  const { question } = useCollabContext();
+
+  if (!question) return;
+
   return (
     <div className="h-[calc(100vh-60px)]">
-      <ProblemDescription />
+      <ProblemDescription question={question} />
     </div>
   );
 };

--- a/frontend/src/components/collab/ProblemPanel.tsx
+++ b/frontend/src/components/collab/ProblemPanel.tsx
@@ -1,10 +1,15 @@
+"use client";
+
 import { useCollabContext } from "@/contexts/collab";
 import ProblemDescription from "../common/ProblemDescription";
+import { notFound } from "next/navigation";
 
 const ProblemPanel = () => {
   const { question } = useCollabContext();
 
-  if (!question) return;
+  if (!question) {
+    return notFound();
+  }
 
   return (
     <div className="h-[calc(100vh-60px)]">

--- a/frontend/src/components/collab/chat/ChatBubble.tsx
+++ b/frontend/src/components/collab/chat/ChatBubble.tsx
@@ -8,11 +8,9 @@ interface ChatBubbleProps {
 const ChatBubble = ({ message, isSelf }: ChatBubbleProps) => {
   return (
     <li
-      key={message.uuid}
       className={`flex items-center ${isSelf ? "ml-10 justify-end" : "mr-10"}`}
     >
       <p
-        key={message.uuid}
         className={`${
           isSelf
             ? "bg-yellow text-black text-sm"

--- a/frontend/src/components/collab/chat/ChatSpace.tsx
+++ b/frontend/src/components/collab/chat/ChatSpace.tsx
@@ -7,7 +7,6 @@ import { Button, Divider } from "@nextui-org/react";
 import ProfilePictureAvatar from "@/components/common/ProfilePictureAvatar";
 import { useCollabContext } from "@/contexts/collab";
 import ChatMessage from "@/types/chat_message";
-import { v4 as uuid } from "uuid";
 
 interface IChatSpaceProps {
   onClose: () => void;
@@ -38,7 +37,7 @@ const ChatSpace = ({ onClose }: IChatSpaceProps) => {
   }, []);
 
   useEffect(() => {
-    if (newMessage.content !== "") {
+    if (newMessage.content !== "" && newMessage.senderId !== user.id) {
       setMessages([...messages, newMessage]);
       setNewMessages({ content: "", senderId: "" });
       scrollToNewestMessage();
@@ -54,7 +53,6 @@ const ChatSpace = ({ onClose }: IChatSpaceProps) => {
     }
 
     const message = {
-      uuid: uuid(),
       content: messageContent,
       senderId: user.id!,
     };

--- a/frontend/src/components/collab/chat/ChatSpace.tsx
+++ b/frontend/src/components/collab/chat/ChatSpace.tsx
@@ -23,7 +23,6 @@ const ChatSpace = ({ onClose }: IChatSpaceProps) => {
   const [messages, setMessages] = useState<ChatMessage[]>([]);
 
   const [newMessage, setNewMessages] = useState<ChatMessage>({
-    uuid: "",
     content: "",
     senderId: "",
   });
@@ -39,12 +38,9 @@ const ChatSpace = ({ onClose }: IChatSpaceProps) => {
   }, []);
 
   useEffect(() => {
-    if (
-      newMessage.content !== "" &&
-      newMessage.uuid != messages[messages.length - 1]?.uuid
-    ) {
+    if (newMessage.content !== "") {
       setMessages([...messages, newMessage]);
-      setNewMessages({ uuid: "", content: "", senderId: "" });
+      setNewMessages({ content: "", senderId: "" });
       scrollToNewestMessage();
     }
   }, [newMessage]);
@@ -92,7 +88,11 @@ const ChatSpace = ({ onClose }: IChatSpaceProps) => {
         {
           <ul className="space-y-3 px-4">
             {messages.map((item) => (
-              <ChatBubble message={item} isSelf={item.senderId === user.id!} />
+              <ChatBubble
+                key={crypto.randomUUID()}
+                message={item}
+                isSelf={item.senderId === user.id!}
+              />
             ))}
           </ul>
         }

--- a/frontend/src/components/common/ProblemDescription.tsx
+++ b/frontend/src/components/common/ProblemDescription.tsx
@@ -5,13 +5,11 @@ import { FC } from "react";
 import ComplexityChip from "../question/ComplexityChip";
 import { Divider } from "@nextui-org/react";
 import parse from "html-react-parser";
-import { useCollabContext } from "@/contexts/collab";
 
-const ProblemDescription: FC = () => {
-  const { question } = useCollabContext();
-
-  if (!question) return;
-
+interface IProblemDescriptionProps {
+  question: Question;
+}
+const ProblemDescription: FC<IProblemDescriptionProps> = ({ question }) => {
   return (
     <div className="flex px-0 py-4 h-[calc(100vh-94px)] overflow-y-auto">
       <div className="w-full px-5">

--- a/frontend/src/components/common/ProblemDescription.tsx
+++ b/frontend/src/components/common/ProblemDescription.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import Question from "@/types/question";
 import { FC } from "react";
 import ComplexityChip from "../question/ComplexityChip";

--- a/frontend/src/components/dashboard/Dashboard.tsx
+++ b/frontend/src/components/dashboard/Dashboard.tsx
@@ -7,7 +7,7 @@ import QuestionStatisticsCard from "./QuestionStatisticsCard";
 
 const Dashboard = () => {
   return (
-    <div className="grid md:grid-rows-2 md:grid-cols-4 gap-4 p-[30px] sm:grid-row-3 sm:grid-cols-2 container mx-auto">
+    <div className="grid md:grid-rows-2 md:grid-cols-4 gap-4 p-[30px] h-[92vh] sm:grid-row-3 sm:grid-cols-2 container mx-auto">
       <div className="row-start-1 col-start-1">
         <ProfileDashboardCard />
       </div>

--- a/frontend/src/components/matching/MatchingLobby.tsx
+++ b/frontend/src/components/matching/MatchingLobby.tsx
@@ -1,16 +1,11 @@
 "use client";
 import { getLogger } from "@/helpers/logger";
-import { getMatchingSocketConfig } from "@/helpers/matching/matching_api_wrappers";
-import { useAuthContext } from "@/contexts/auth";
-import Partner from "@/types/partner";
 import { Modal, ModalContent } from "@nextui-org/react";
 import { useEffect, useState } from "react";
 import MatchingLobbyErrorView from "./MatchingLobbyErrorView";
 import MatchingLobbyMatchingView from "./MatchingLobbyMatchingView";
 import MatchingLobbyNoMatchView from "./MatchingLobbyNoMatchView";
-import MatchingLobbySuccessView, {
-  MatchingSuccessState,
-} from "./MatchingLobbySuccessView";
+import MatchingLobbySuccessView from "./MatchingLobbySuccessView";
 import { MATCHING_STAGE } from "@/types/enums";
 import SocketService from "@/helpers/matching/socket_service";
 import MatchingLobbyPrepCollabView from "./MatchingLobbyPrepCollabView";
@@ -71,8 +66,8 @@ export default function MatchingLobby({
 
   const handleRedirect = (socket: SocketService, room: any) => {
     const partnerId = socket.getRoomPartner()!.id;
+
     const path = `${CLIENT_ROUTES.COLLABORATION}/${room.id}?partnerId=${partnerId}&questionId=${room.questionId}&language=${room.language}`;
-    console.log(path);
     router.push(path);
   };
 

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -97,7 +97,6 @@ const AuthProvider = ({ children }: IAuthProvider) => {
   };
 
   const isAuthenticated = () => {
-    console.log(user.id);
     return !!user.id;
   };
 

--- a/frontend/src/contexts/collab.tsx
+++ b/frontend/src/contexts/collab.tsx
@@ -113,24 +113,24 @@ const CollabProvider = ({ children }: ICollabProvider) => {
 
       setMatchedLanguage(matchedLanguage.toLowerCase());
 
-      // TODO: refactor this to Promise.all
-      const partner = await UserService.getUserById(partnerId);
+      const promises = [
+        UserService.getUserById(partnerId),
+        getQuestionById(questionId),
+      ];
 
-      if (!partner) {
-        setIsNotFoundError(true);
-        return;
-      }
+      Promise.all(promises).then((responses) => {
+        const partner = responses[0] as User;
+        const question = responses[1] as Question;
 
-      setPartner(partner);
+        if (!partner || !question) {
+          setIsNotFoundError(true);
+          return;
+        }
 
-      const question = (await getQuestionById(questionId)) as Question;
+        setPartner(partner);
+        setQuestion(question);
+      });
 
-      if (!question) {
-        setIsNotFoundError(true);
-        return;
-      }
-
-      setQuestion(question);
       await initializeSocket(roomId);
     } catch (error) {
       console.log(error);

--- a/frontend/src/contexts/collab.tsx
+++ b/frontend/src/contexts/collab.tsx
@@ -57,7 +57,7 @@ const CollabProvider = ({ children }: ICollabProvider) => {
   const [isSocketConnected, setIsSocketConnected] = useState<boolean>(false);
   const [roomId, setRoomId] = useState<string>("");
   const intervalRef = useRef<NodeJS.Timeout>();
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
   const [partner, setPartner] = useState<User>();
   const [question, setQuestion] = useState<Question>();
   const [matchedLanguage, setMatchedLanguage] = useState<string>("");
@@ -91,6 +91,7 @@ const CollabProvider = ({ children }: ICollabProvider) => {
   ) => {
     setIsLoading(true);
     try {
+      console.log("Enter handleConnectToRoom");
       // check if we have an authenticated user, a not-null partnerId, questionId, matchedLanguage, and roomId
       if (!user || !partnerId || !questionId || !matchedLanguage || !roomId) {
         setIsNotFoundError(true);
@@ -118,18 +119,26 @@ const CollabProvider = ({ children }: ICollabProvider) => {
         getQuestionById(questionId),
       ];
 
-      Promise.all(promises).then((responses) => {
-        const partner = responses[0] as User;
-        const question = responses[1] as Question;
+      Promise.all(promises)
+        .then((responses) => {
+          const partner = responses[0] as User;
+          const question = responses[1] as Question;
 
-        if (!partner || !question) {
+          if (!partner || !question) {
+            setIsNotFoundError(true);
+            return;
+          }
+
+          setPartner(partner);
+          setQuestion(question);
+        })
+        .catch((error) => {
           setIsNotFoundError(true);
-          return;
-        }
+        });
 
-        setPartner(partner);
-        setQuestion(question);
-      });
+      if (isNotFoundError) {
+        return;
+      }
 
       await initializeSocket(roomId);
     } catch (error) {

--- a/frontend/src/helpers/collaboration/socket_service.ts
+++ b/frontend/src/helpers/collaboration/socket_service.ts
@@ -41,7 +41,6 @@ class SocketService {
   };
 
   sendCodeChange = (content: string) => {
-    console.log("Code change: ", content);
     this.socket.emit(SocketEvent.CODE_CHANGE, {
       roomId: this.roomId,
       content: content,
@@ -51,14 +50,12 @@ class SocketService {
   receiveCodeUpdate = (
     setCurrentCode: React.Dispatch<React.SetStateAction<string>>
   ) => {
-    console.log("Code updating..");
     this.socket.on(SocketEvent.CODE_UPDATE, (content: string) => {
       setCurrentCode(content);
     });
   };
 
   sendChatMessage = (message: ChatMessage) => {
-    console.log("sending message: ", message);
     this.socket.emit(SocketEvent.SEND_CHAT_MESSAGE, {
       roomId: this.roomId,
       message: message,
@@ -69,7 +66,6 @@ class SocketService {
     setNewMessages: React.Dispatch<React.SetStateAction<ChatMessage>>
   ) => {
     this.socket.on(SocketEvent.UPDATE_CHAT_MESSAGE, (message: ChatMessage) => {
-      console.log("newMessage:", message);
       setNewMessages(message);
     });
   };

--- a/frontend/src/helpers/matching/matching_api_wrappers.tsx
+++ b/frontend/src/helpers/matching/matching_api_wrappers.tsx
@@ -1,4 +1,4 @@
-"use server"
+"use server";
 import { SERVICE } from "@/types/enums";
 import { getSocketConfig } from "../endpoint";
 import { getLogger } from "../logger";
@@ -8,29 +8,8 @@ const logger = getLogger("wrapper");
 //TODO: change preferences to be a type
 export async function submitMatchPreferences(preferences: {}) {
   console.log(`Submitted for matching: ${JSON.stringify(preferences)}`);
-};
+}
 
 export async function getMatchingSocketConfig() {
   return await getSocketConfig(SERVICE.MATCHING);
-}
-
-export async function getMatchedRecord(
-  {
-    firstUserId,
-    secondUserId,
-    questionId,
-    matchedLanguage,
-  }: {
-    firstUserId: string;
-    secondUserId: string;
-    questionId: string;
-    matchedLanguage: string;
-  }
-) {
-  return {
-    firstUserId: firstUserId,
-    secondUserId: secondUserId,
-    questionId: questionId,
-    matchedLanguage: matchedLanguage,
-  };
 }

--- a/frontend/src/types/chat_message.d.ts
+++ b/frontend/src/types/chat_message.d.ts
@@ -1,5 +1,4 @@
 type ChatMessage = {
-  uuid: string;
   content: string;
   senderId: string;
 };

--- a/frontend/src/utils/hashUtils.ts
+++ b/frontend/src/utils/hashUtils.ts
@@ -1,0 +1,20 @@
+import crypto from "crypto";
+
+export function verifyRoomParamsIntegrity(
+  roomId: string,
+  userId: string,
+  partnerId: string,
+  questionId: string,
+  language: string
+): boolean {
+  const hasher = crypto.createHash("sha256");
+  hasher.update(userId + partnerId + questionId + language.toLowerCase());
+  const isRoomHostHash = hasher.digest("hex").slice(0, 20);
+
+  const newHaher = crypto.createHash("sha256");
+  newHaher.update(partnerId + userId + questionId + language.toLowerCase());
+  const isRoomPartnerHash = newHaher.digest("hex").slice(0, 20);
+
+  // either the current user is the room host, or the partner
+  return roomId === isRoomHostHash || roomId === isRoomPartnerHash;
+}


### PR DESCRIPTION
# Pull Request

## Description
<!-- [Provide a brief description of the changes introduced by this PR. Explain the problem it solves or the feature it adds.] -->
I have updated the collab context function to ensure that the collaboration workspace page is able to render. I also did a little bit of code refactoring, and removed unnecessary console.log.

I also fixed the unique key issue that ly faced, and thus removed the message uuid and the uuid package. 

There are still some works left undone, please refer to the additional notes.

## Related Issue(s)
<!-- [Link to any related issues or tasks, e.g., "Closes #123" or "Fixes #456."] -->
Fixes #93, #95 

## Changes Made
<!-- [List the specific changes made in this PR, such as code modifications, new files, or updates to documentation.] -->
- update `handleConnectToRoom` in `collab.tsx`
- create a `hashUtils` for verifying room id checksum
- added a `isNotFound` state value in the collab context, the reason is that if we simply throw `notFound()` in `handleConnectToRoom`, the error will not be reflected in the collaboration room page, hence we need this error state to reflect the 404
- code clean up, removed some console log, first to improve efficiency (we don't want to show the code changes during collaboration as it will cause latency, and we also don't want to show the message sent in the console every time we sent a message), next is for cleanliness (we don't want to print a random user id, or whatever id in the console)
- fixed the height issue in the dashboard page

## Screenshots (if applicable)
<!-- [Include screenshots or images to visually showcase the changes, if applicable.] -->
Not sure how to show the result, but now the below page uses the values returned from matching, and it now supports concurrent update (thanks @weidak )
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g05/assets/69421979/a5ee188f-edd8-44e6-a8e3-4d77fcc8ad61)

## Checklist
- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->
I want to list out a few things that we need to do:
1. We might need a way to show the partner connection status, so that we know if our partner loses the connection.
2. We need a way to enforce the 2-hour limit for our collaboration workspace. This might need to use database to store the remaining time, so that even if the user closes the browser and joined back, the time is still correct.
3. We need to indicate that there is a new message coming when one sent an message. We likely want to use the [Badge ](https://nextui.org/docs/components/badge)in Next-Ui.
4. When the user left the session by closing the browser and joined back the room, the chat history is lost, we might need to restore the chat history in the future. This will be one of the requirements in the history service.
5. Same for code. When the user left and joined back the room, he will not be able to see the latest code, but the default code only.

More issues are coming...
6. We need a way to standardise the size of each user avatar, this is for better UI:
As we can see here, the "Mr Test" profile is more in ellipse shape while our "John Doe" profile is more in circular shape. 
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g05/assets/69421979/f6c87e76-e6f0-444b-b895-5b9bd6eda1c0)
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g05/assets/69421979/a5cfae81-3ee4-4579-b9db-d1e3f6267377)
This is quite obvious when we run a match, and it can go even worse if one image is much higher/wider than the other.
![image](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g05/assets/69421979/488ab7ab-299a-4347-a30b-d9e131b8eceb)

7. For matching, right now we might not have all the questions available for each topic that the user chose, I think we need to add more questions.
