### PR TITLE
Update question description validator to only count the non-HTML tags element

### DIFF
--- a/backend/question-service/src/__tests__/unit/put-question.test.ts
+++ b/backend/question-service/src/__tests__/unit/put-question.test.ts
@@ -104,6 +104,30 @@ describe("PUT /api/questions/:questionId", () => {
     });
   });
 
+  describe("Given the description contains all HTML new line tags", () => {
+    it("should return 400 with a zod error message indicating that the description is too short", async () => {
+      // Arrange
+      const questionId = "existingquestionid123";
+      const updateQuestionRequestBody =
+        TestPayload.getCreateQuestionRequestBody();
+      updateQuestionRequestBody.description = "<br /><br /><br />";
+      dbMock.question.findFirst = jest
+        .fn()
+        .mockResolvedValue(TestPayload.getQuestionPayload(questionId));
+
+      // Act
+      const { body, statusCode } = await supertest(app)
+        .put(`/api/questions/${questionId}`)
+        .send(updateQuestionRequestBody);
+
+      // Assert
+      expect(statusCode).toEqual(HttpStatusCode.BAD_REQUEST);
+      expect(body.message).toEqual(
+        "Invalid description. String must contain at least 3 character(s)"
+      );
+    });
+  });
+
   describe("Given an empty request body", () => {
     it("should return 400 with an empty request body alert message", async () => {
       // Arrange

--- a/backend/question-service/src/lib/validators/CreateQuestionValidator.ts
+++ b/backend/question-service/src/lib/validators/CreateQuestionValidator.ts
@@ -4,7 +4,12 @@ import { convertStringToComplexity } from "../enums/Complexity";
 
 export const CreateQuestionValidator = z.object({
   title: z.string().min(3).max(100),
-  description: z.string().min(3),
+  description: z.string().refine((value) => {
+    // Remove HTML tags using a regular expression
+    const plainText = value.replace(/<[^>]*>/g, "");
+
+    return plainText.length >= 3;
+  }, "Invalid description. String must contain at least 3 character(s)"),
   topics: z
     .array(z.string().transform(convertStringToTopic))
     .refine((topics) => topics.length > 0, "At least one topic is required.")

--- a/backend/question-service/src/lib/validators/UpdateQuestionValidator.ts
+++ b/backend/question-service/src/lib/validators/UpdateQuestionValidator.ts
@@ -4,7 +4,15 @@ import { convertStringToComplexity } from "../enums/Complexity";
 
 export const UpdateQuestionValidator = z.object({
   title: z.string().min(3).max(100).optional(),
-  description: z.string().min(3).optional(),
+  description: z
+    .string()
+    .refine((value) => {
+      // Remove HTML tags using a regular expression
+      const plainText = value.replace(/<[^>]*>/g, "");
+
+      return plainText.length >= 3;
+    }, "Invalid description. String must contain at least 3 character(s)")
+    .optional(),
   topics: z
     .array(z.string().transform(convertStringToTopic))
     .refine((topics) => topics.length > 0, "At least one topic is required.")

--- a/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
+++ b/frontend/src/app/(pages)/collaboration/room/[roomId]/page.tsx
@@ -39,10 +39,6 @@ const page: FC<pageProps> = ({ params: { roomId } }) => {
     };
   }, []);
 
-  if (isNotFoundError) {
-    return notFound();
-  }
-
   return (
     <div>
       {isLoading ? (

--- a/frontend/src/components/collab/ProblemPanel.tsx
+++ b/frontend/src/components/collab/ProblemPanel.tsx
@@ -5,9 +5,9 @@ import ProblemDescription from "../common/ProblemDescription";
 import { notFound } from "next/navigation";
 
 const ProblemPanel = () => {
-  const { question, isNotFoundError } = useCollabContext();
+  const { question } = useCollabContext();
 
-  if (!question || isNotFoundError) {
+  if (!question) {
     return notFound();
   }
 


### PR DESCRIPTION
# Pull Request

## Description
<!-- [Provide a brief description of the changes introduced by this PR. Explain the problem it solves or the feature it adds.] -->
As we will pass the description as HTML, the question description length constraint becomes insignificant. Hence, I have updated the validator to only count the non-HTML tags characters by using regex. I also pushed the code clean up that should be done in the previous merged PR (apologise that just now I forgot to push it!!!)

## Related Issue(s)
<!-- [Link to any related issues or tasks, e.g., "Closes #123" or "Fixes #456."] -->
Fixes #97 

## Changes Made
<!-- [List the specific changes made in this PR, such as code modifications, new files, or updates to documentation.] -->
- update create question and update question validator
- create a new test case to ensure the correctness
- code clean up for collaboration pages frontend

## Screenshots (if applicable)
<!-- [Include screenshots or images to visually showcase the changes, if applicable.] -->

## Checklist
- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->

