### PR TITLE
Fix invalid connection headers in middleware due to os/node vers

### DIFF
--- a/backend/question-service/src/middleware/auth.ts
+++ b/backend/question-service/src/middleware/auth.ts
@@ -11,6 +11,22 @@ export const authMiddleware = async (
     return;
   }
 
+  const cookies = req.headers.cookie;
+
+  const jwtCookieString = cookies
+    ?.split(";")
+    .find((cookie) => cookie.split("=")[0].trim() == "jwt")
+    ?.split("=")[1];
+
+  //If there is no JWT, do not need to go through auth
+  if (!jwtCookieString) {
+    res.status(HttpStatusCode.UNAUTHORIZED).json({
+      error: "Unauthorised",
+      message: "Unauthorised",
+    });
+    return;
+  }
+
   // Only allow GET requests to /api/questions to pass through with just user rights
   const authEndpoint =
     req.method === "GET"
@@ -21,8 +37,7 @@ export const authMiddleware = async (
   const authRes = await fetch(authEndpoint, {
     method: "POST",
     headers: {
-      ...(req.headers as HeadersInit), // Pass headers from the incoming request
-      "content-length": "0", // Override content-length to 0
+      Cookie: `jwt=${jwtCookieString}`,
     },
   });
 

--- a/backend/user-service/src/middleware/auth.ts
+++ b/backend/user-service/src/middleware/auth.ts
@@ -20,13 +20,30 @@ export const authMiddleware = async (
     return;
   }
 
+  const cookies = req.headers.cookie;
+
+  const jwtCookieString = cookies
+    ?.split(";")
+    .find((cookie) => cookie.split("=")[0].trim() == "jwt")
+    ?.split("=")[1];
+
+  //If there is no JWT, do not need to go through auth
+  if (!jwtCookieString) {
+    res.status(HttpStatusCode.UNAUTHORIZED).json({
+      error: "Unauthorised",
+      message: "Unauthorised",
+    });
+    return;
+  }
+
+  //If there is JWT, validate it through the auth endpoint
   const authEndpoint =
     process.env.AUTH_ENDPOINT || "http://localhost:5050/api/auth/validate";
+
   const authRes = await fetch(authEndpoint, {
     method: "POST",
     headers: {
-      ...(req.headers as HeadersInit), // Pass headers from the incoming request
-      "content-length": "0", // Override content-length to 0
+      Cookie: `jwt=${jwtCookieString}`,
     },
   });
 

--- a/frontend/src/contexts/auth.tsx
+++ b/frontend/src/contexts/auth.tsx
@@ -80,7 +80,6 @@ const AuthProvider = ({ children }: IAuthProvider) => {
   const logIn = async (email: string, password: string) => {
     await AuthService.logInByEmail(email, password);
     await fetchUser(true);
-    console.log("logged in!");
   };
 
   const logOut = async () => {

--- a/frontend/src/helpers/endpoint.ts
+++ b/frontend/src/helpers/endpoint.ts
@@ -83,9 +83,13 @@ export default async function api(config: ApiConfig): Promise<ApiResponse> {
     // If the response contains a JWT cookie, set it in the browser.
     const resCookie = res.headers.get("set-cookie");
     if (resCookie) {
-      const cookieVal = resCookie.split("=");
-      if (cookieVal[0] == "jwt") {
-        cookies().set("jwt", cookieVal[1].split("; ")[0], {
+      const jwtCookieString = resCookie
+        ?.split(";")
+        .find((cookie) => cookie.split("=")[0].trim() == "jwt")
+        ?.split("=")[1];
+
+      if (jwtCookieString) {
+        cookies().set("jwt", jwtCookieString, {
           httpOnly: true,
           secure: false,
         });


### PR DESCRIPTION
# Pull Request

## Description
<!-- [Provide a brief description of the changes introduced by this PR. Explain the problem it solves or the feature it adds.] -->
@tryyang2001 encounters the following error when the api routes go through auth middleware:
![telegram-cloud-photo-size-5-6154423140437047210-y](https://github.com/CS3219-AY2324S1/ay2324s1-course-assessment-g05/assets/69505852/b2b6ddee-a448-4711-aced-5670c0e11012)

I was unable to replicate the issue on my device, so this is likely due to a OS or node version difference.
Either ways, Rui Yang helped me figure out that the problem lies in the header forwarding. The updated way now works for both my device and his :) Thanks ry! :D 

## Related Issue(s)
<!-- [Link to any related issues or tasks, e.g., "Closes #123" or "Fixes #456."] -->

## Changes Made
<!-- [List the specific changes made in this PR, such as code modifications, new files, or updates to documentation.] -->
1. Change the Auth middleware implementation in User and Question backend so that the JWT cookie from incoming request is manually extracted and added into the header of the outgoing request to Auth
2. Minor changes to JWT cookie extraction in the frontend

## Screenshots (if applicable)
<!-- [Include screenshots or images to visually showcase the changes, if applicable.] -->

## Checklist
- [x] I have checked that the changes included in the PR are intended to merge to `master` or any destination branch.
- [x] I have verified that the new changes do not break any existing functionalities, unless the new changes are intended and have approved by the team.
- [x] I will take care of the merging and delete the side-branch after the PR is merged.

## Additional Notes/References
<!-- [Add any additional notes, comments, or context that might be helpful for reviewers or future reference.] -->

